### PR TITLE
Return `Iterable` instead of `IterableIterator`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,4 +16,7 @@ console.log([...chunkify([1, 2, 3, 4], 3)]);
 //=> [[1, 2, 3], [4]]
 ```
 */
-export default function chunkify<T>(iterable: Iterable<T>, chunkSize: number): IterableIterator<T[]>;
+export default function chunkify<T>(
+	iterable: Iterable<T>,
+	chunkSize: number
+): Iterable<T[]>;

--- a/index.js
+++ b/index.js
@@ -1,32 +1,38 @@
-export default function * chunkify(iterable, chunkSize) {
+export default function chunkify(iterable, chunkSize) {
 	if (typeof iterable[Symbol.iterator] !== 'function') {
 		throw new TypeError('Expected an `Iterable` in the first argument');
 	}
 
 	if (!(Number.isSafeInteger(chunkSize) && chunkSize > 0)) {
-		throw new TypeError(`Expected \`chunkSize\` to be a an integer from 1 and up, got \`${chunkSize}\``);
+		throw new TypeError(
+			`Expected \`chunkSize\` to be a an integer from 1 and up, got \`${chunkSize}\``
+		);
 	}
 
-	if (Array.isArray(iterable)) {
-		for (let index = 0; index < iterable.length; index += chunkSize) {
-			yield iterable.slice(index, index + chunkSize);
+	return {
+		* [Symbol.iterator]() {
+			if (Array.isArray(iterable)) {
+				for (let index = 0; index < iterable.length; index += chunkSize) {
+					yield iterable.slice(index, index + chunkSize);
+				}
+
+				return;
+			}
+
+			let chunk = [];
+
+			for (const value of iterable) {
+				chunk.push(value);
+
+				if (chunk.length === chunkSize) {
+					yield chunk;
+					chunk = [];
+				}
+			}
+
+			if (chunk.length > 0) {
+				yield chunk;
+			}
 		}
-
-		return;
-	}
-
-	let chunk = [];
-
-	for (const value of iterable) {
-		chunk.push(value);
-
-		if (chunk.length === chunkSize) {
-			yield chunk;
-			chunk = [];
-		}
-	}
-
-	if (chunk.length > 0) {
-		yield chunk;
-	}
+	};
 }


### PR DESCRIPTION
Using generator functions means that an iterable can only be used once. To demonstrate

```js
function* generator() {
  let index = 0;
  while (true) {
    yield index++;
  }
}

const g = generator()

g.next().value // 0
g.next().value // 1
g[Symbol.iterator]().next().value // 2
```

To solve this issue, chunkify can instead return an iterable object (with a generator function in `@@iterator`). This has the bonus of `TyperError` throwing straight away, rather than lazily on the first `next()` call.